### PR TITLE
Filter out routes with undefined components

### DIFF
--- a/src/trigger.js
+++ b/src/trigger.js
@@ -1,6 +1,9 @@
 export default (name, components, locals) => {
   const promises = (Array.isArray(components) ? components : [components])
 
+    // Filter out routes without defined components
+    .filter(component => !!component)
+
     // Get component lifecycle handler functions
     .map(component => ({ component, handlers: component.__redial_handlers__ }))
 


### PR DESCRIPTION
Routes can have undefined components:

``` javascript
<Route path="/">
  <IndexRoute component={Home} />
  <Route path="/:page" component={Page} />
</Route>
```

This patch filters them out.
