### PR TITLE
Fix imports for client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ import { trigger } from 'redial';
 
 import React from 'react';
 import { render } from 'react-dom';
-import { Router, RouterContext, browserHistory } from 'react-router';
+import { Router, browserHistory, match } from 'react-router';
 import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';


### PR DESCRIPTION
Thanks for this library @markdalgleish, it's really helpful.

This PR fixes the client example which is missing `match` import and leaving unused `RouterContext`
