### PR TITLE
Avoid unsafe behavior in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ import routes from './routes';
 export default container => {
   // Your server rendered response needs to expose the state of the store, e.g.
   // <script>
-  //   window.INITIAL_STATE = <%- JSON.stringify(state)%>
+  //   window.INITIAL_STATE = <%- require('serialize-javascript')(state)%>
   // </script>
   const initialState = window.INITIAL_STATE;
 


### PR DESCRIPTION
This is probably a minor nit... But I worry that people will follow an unsafe example because they don't know any better. I definitely would've fallen into that trap not so long ago.

My suggested change is to replace `JSON.stringify` with [`serialize-javascript`](https://github.com/yahoo/serialize-javascript), which does automatic escaping of HTML characters.

I don't know if just using it in the example is enough, or if it would be a good idea to add a note / warning. 
