### PR TITLE
Enable bundling with Babel 6

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
+.babelrc
 src


### PR DESCRIPTION
I'm attempting to use `redial` in my project where I have Webpack bundling it with `babel`/`babel-loader` version 6.x. Unfortunately, `babel-loader` is loading up and choking on `redial`'s `.babelrc` file, which has a Babel 5 option (`optional: es7.decorators`) that was removed in Babel 6:

```
ERROR in ./~/redial/lib/index.js
Module build failed: ReferenceError: [BABEL] /myapp/node_modules/redial/lib/index.js: Using removed Babel 5 option: /myapp/node_modules/redial/.babelrc.optional - Put the specific transforms you want in the `plugins` option
...
at Object.module.exports (/myapp/node_modules/babel-loader/index.js:88:12)
```

Since `redial` builds on `npm prepublish` and doesn't include `src` in its package, it seems like its `.babelrc` shouldn't be there in the package anyway. I verified that removing it from the published package fixes this issue.

You might consider upgrading `redial` to Babel 6 as well.
