### PR TITLE
catch unwanted removal of returning a dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 lib
 coverage
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 coverage
+.vscode

--- a/src/trigger.js
+++ b/src/trigger.js
@@ -1,4 +1,4 @@
-import propName from './propName';
+import propName from "./propName";
 
 export default (name, components, locals) => {
   const promises = (Array.isArray(components) ? components : [components])
@@ -16,14 +16,23 @@ export default (name, components, locals) => {
     .map(({ component, hooks }) => {
       const hook = hooks[name];
 
-      if (typeof hook !== 'function') {
+      if (typeof hook !== "function") {
         return;
       }
 
       try {
-        return typeof locals === 'function' ?
-          hook(locals(component)) :
-          hook(locals);
+        const trigger =
+          typeof locals === "function"
+            ? hook(locals(component))
+            : hook(locals);
+
+        if (trigger && !trigger.then || !tigger) {
+          console.warn(
+            "fetch does not return a promise. In this case redial execute then immediately and does not wait for async operations. Please check return (also implicit) of the defined fetch function."
+          );
+        }
+
+        return trigger;
       } catch (err) {
         return Promise.reject(err);
       }

--- a/src/trigger.js
+++ b/src/trigger.js
@@ -21,12 +21,12 @@ export default (name, components, locals) => {
       }
 
       try {
-        const trigger =
+        const promise =
           typeof locals === 'function'
             ? hook(locals(component))
             : hook(locals);
 
-        const isNoPromise = (trigger && !trigger.then) || !tigger;
+        const isNoPromise = (promise && !promise.then) || !promise;
 
         const isDev =
           process && process.env && process.env.NODE_ENV === 'development';
@@ -37,7 +37,7 @@ export default (name, components, locals) => {
           );
         }
 
-        return trigger;
+        return promise;
       } catch (err) {
         return Promise.reject(err);
       }

--- a/src/trigger.js
+++ b/src/trigger.js
@@ -1,4 +1,4 @@
-import propName from "./propName";
+import propName from './propName';
 
 export default (name, components, locals) => {
   const promises = (Array.isArray(components) ? components : [components])
@@ -16,19 +16,19 @@ export default (name, components, locals) => {
     .map(({ component, hooks }) => {
       const hook = hooks[name];
 
-      if (typeof hook !== "function") {
+      if (typeof hook !== 'function') {
         return;
       }
 
       try {
         const trigger =
-          typeof locals === "function"
+          typeof locals === 'function'
             ? hook(locals(component))
             : hook(locals);
 
         if (trigger && !trigger.then || !tigger) {
           console.warn(
-            "fetch does not return a promise. In this case redial execute then immediately and does not wait for async operations. Please check return (also implicit) of the defined fetch function."
+            'fetch does not return a promise. In this case redial execute then immediately and does not wait for async operations. Please check return (also implicit) of the defined fetch function.'
           );
         }
 

--- a/src/trigger.js
+++ b/src/trigger.js
@@ -26,9 +26,14 @@ export default (name, components, locals) => {
             ? hook(locals(component))
             : hook(locals);
 
-        if (trigger && !trigger.then || !tigger) {
+        const isNoPromise = (trigger && !trigger.then) || !tigger;
+
+        const isDev =
+          process && process.env && process.env.NODE_ENV === 'development';
+
+        if (isNoPromise && isDev) {
           console.warn(
-            'fetch does not return a promise. In this case redial execute then immediately and does not wait for async operations. Please check return (also implicit) of the defined fetch function.'
+            'fetch does not return a promise. In this case redial execute "then" immediately and does not wait for async operations. Please check return (also implicit) of the defined fetch function.'
           );
         }
 


### PR DESCRIPTION
Hi,

Thank you for your awesome work. I want to propose this PR, because me and some folks of my team are running into an issue which is hard to identify and VERY time consuming. 

`const redial = {
  fetch: ({ dispatch, httpClient, props }) =>
    dispatch(loadThings(httpClient, props.things))
};`

When you have a redial object like this, you have no hint that it is necessary for fetch to return a promise. This is going to be a problem when you start debugging and put curly braces around the body of arrow function.

`const redial = {
  fetch: ({ dispatch, httpClient, props }) => {
    console.log("props", props);
    dispatch(loadThings(httpClient, props.things));
  }
};`

I couldn't think of any usecase where you don't want to return a promise to resolve after async operation. Maybe i'am wrong. What do you think?

greetings
Fabricius


